### PR TITLE
Fix vertical line placement and potential race conditions

### DIFF
--- a/samples/responsive.html
+++ b/samples/responsive.html
@@ -10,189 +10,114 @@
         />
         <link rel="stylesheet" href="https://cdn.toolkit.illinois.edu/ilw-global/3/ilw-global.css">
         <script type="module" src="/src/ilw-org-chart.ts"></script>
-    </head>
 
-    <body>
+            <script type="module">
+                document.getElementById("org-chart").org = {
+                    "title": "Executive Sponsor",
+                    "large": true,
+                    "children": [
+                        {
+                            "title": "Institutional Data Governance Board",
+                            "large": true,
+                            "children": [
+                                {
+                                    "title": "DSC – Advancement, Alumni, and Foundation Data"
+                                },
+                                {
+                                    "title": "DSC – Financial Data"
+                                },
+                                {
+                                    "title": "DSC – Human Resources Data"
+                                },
+                                {
+                                    "title": "DSC – Institutional Administrative Research Data",
+                                    "weight": 1
+                                },
+                                {
+                                    "title": "DSC – IT and Systems Data",
+                                    "weight": 1
+                                },
+                                {
+                                    "title": "DSC – Student and Academic Data",
+                                    "weight": 1
+                                }
+                            ]
+                        }
+                    ]
+                };
+            </script>
+            <script>
+                document.addEventListener('DOMContentLoaded', function() {
+                    document.getElementById('loadJson').addEventListener('click', function(event) {
+                        window.scrollTo({
+                            top: 0,
+                            left: 0,
+                            behavior: "instant",
+                        });
+                        document.getElementById("original").style.display = "none";
+                        document.getElementById("new").style.display = "block";
+                        document.getElementById("holder").innerHTML = "";
+                        let chart = document.createElement("ilw-org-chart");
+                        chart.setAttribute("responsive", "true");
+                        chart.org = JSON.parse(document.getElementById("json").value);
+                        document.getElementById("holder").appendChild(chart);
+                    });
+                });
+            </script>
+        </head>
+
+        <body style="margin: 0; padding: 0">
 
         <main>
-            <div style="padding: 100px;">
-                <ilw-org-chart id="chart" responsive="true"></ilw-org-chart>
+            <ilw-content width="page"><h1>Org Chart</h1></ilw-content>
+            <div id="original" style="padding: 0 10px;">
+                <ilw-org-chart id="org-chart" responsive="true"></ilw-org-chart>
             </div>
+            <div id="new" style="display: none;">
+                <ilw-content width="page"><h2>New Org Chart Generated Below</h2></ilw-content>
+                <div id="holder"></div>
+            </div>
+            <ilw-content width="page">
+                <h2>JSON for Org Chart</h2>
+                <p><button id="loadJson" class="ilw-button">Generate New Chart based on JSON below</button> </p>
+                <p>If you run into issues with the chart not generating, chances are the JSON is not formatted correctly. Go to a <a href="https://jsonlint.com/" target="_blank">JSON Validator (opens in a new window)</a> to see if the JSON is valid.</p>
+                <p>Issues should be logged at <a href="https://github.com/web-illinois/ilw-org-chart/issues">the WIGG Web Component GitHub repository</a> and these will automatically be added to the Toolkit 3.0 project.</p>
+                <p><label for="json">JSON Input Value</label></p>
+                <textarea style="width: 90%; height: 800px;" id="json">
+{
+    "title": "Executive Sponsor",
+    "large": true,
+    "children": [
+        {
+            "title": "Institutional Data Governance Board",
+            "large": true,
+            "children": [
+                {
+                    "title": "DSC – Advancement, Alumni, and Foundation Data"
+                },
+                {
+                    "title": "DSC – Financial Data"
+                },
+                {
+                    "title": "DSC – Human Resources Data"
+                },
+                {
+                    "title": "DSC – Institutional Administrative Research Data",
+                    "weight": 1
+                },
+                {
+                    "title": "DSC – IT and Systems Data","weight": 1
+                },
+                {
+                    "title": "DSC – Student and Academic Data","weight": 1
+                }
+            ]
+        }
+    ]
+}
+            </textarea>
+            </ilw-content>
         </main>
 
-        <script type="module">
-            /**
-             *
-             * @type {Org}
-             */
-            const org = {
-                title: "Vice Chancellor for Student Affairs",
-                subtitle: "Interim",
-                large: true,
-                children: [
-                    {
-                        title: "Administrative Assistant",
-                        weight: -1,
-                    },
-                    {
-                        title: "Director, Advancement",
-                    },
-                    {
-                        title: "Director, Marketing and Communications",
-                    },
-                    {
-                        title: "Associate Vice Chancellor for Student Success and Engagement",
-                        weight: 1,
-                        large: true,
-                        children: [
-                            {
-                                title: "Sr. Assistant Dean, Fraternity and Sorority Affairs",
-                            },
-                            { title: "Director, Illinois Leadership Center" },
-                            { title: "Director, Minority Student Affairs" },
-                            {
-                                title: "Sr. Assistant Dean, New/Transfer Student Programs",
-                            },
-                            { title: "Director, Testing Center" },
-                            { title: "Director, The Career Center" },
-                        ],
-                    },
-                    {
-                        title: "Associate Vice Chancellor for Auxiliary, Health and Wellbeing",
-                        weight: 1,
-                        large: true,
-                        children: [
-                            { title: "Director, Counseling Center" },
-                            { title: "Director, McKinley Health Center" },
-                            { title: "Director, Parking*" },
-                            {
-                                title: "Director, Auxiliary Shared Technology Services",
-                            },
-                            { title: "Director, State Farm Center**" },
-                            { title: "Director, University Housing" },
-                            { title: "Director, Campus Recreation" },
-                            { title: "Director, Illini Union" },
-                        ],
-                    },
-                    {
-                        title: "Associate Vice Chancellor/Dean of Students",
-                        weight: 1,
-                        large: true,
-                        children: [
-                            { title: "Director, Student Conflict Resolution" },
-                            { title: "Director, Student Legal Services" },
-                            {
-                                title: "Director, Tenant Union and Campus and Community Student Services",
-                            },
-                        ],
-                    },
-                    {
-                        title: "Associate Vice Chancellor for the Office of Inclusion and Intercultural Relations",
-                        weight: 1,
-                        large: true,
-                        children: [
-                            {
-                                title: "Director, Asian American Cultural Center",
-                            },
-                            {
-                                title: "Director, Bruce D. Nesbitt African American Cultural Center",
-                            },
-                            { title: "Director, La Casa Cultural Latina" },
-                            {
-                                title: "Director, Diversity and Social Justice Education",
-                            },
-                            { title: "Director, International Education" },
-                            { title: "Director, LGBT Resource Center" },
-                            { title: "Director, Native American House" },
-                            { title: "Director, Women’s Resources Center" },
-                        ],
-                    },
-                    {
-                        title: "Senior Executive Director for Administrative Services",
-                        weight: 1,
-                        large: true,
-                        children: [
-                            { title: "Director, Assessment and Planning" },
-                            { title: "Director, Budget and Finance" },
-                            { title: "Director, Human Resources" },
-                        ],
-                    },
-                ],
-            };
-
-            const org2 = {
-                title: "Vice Chancellor for Research",
-                subtitle: "Interim",
-                large: true,
-                children: [
-                    {
-                        title: "Administrative Assistant",
-                        weight: -1,
-                    },
-                    {
-                        title: "Executive Associate Vice Chancellor/Chief of Staff",
-                    },
-                    {
-                        title: "Associate Vice Chancellor, HR and Finance",
-                        weight: 1,
-                    },
-                    {
-                        title: "Associate Vice Chancellor/Director, Division of Animal Resources",
-                    },
-
-                    {
-                        title: "Executive Director, Strategic Research Communications",
-                        weight: 1,
-                        children: [
-                            {
-                                title: "Proposal Development",
-                            },
-                        ],
-                    },
-                    {
-                        title: "Associate Vice Chancellor, Corporate Relations and Economic Development",
-                    },
-                    {
-                        title: "Senior Director, External Research Partnerships",
-                        weight: 1,
-                    },
-                    {
-                        title: "Associate Vice Chancellor, Humanities, Arts and Related Fields",
-                    },
-                    {
-                        title: "Associate Vice Chancellor",
-                        children: [
-                            {
-                                title: "Sponsored Programs Administration",
-                            },
-                        ],
-                    },
-                    {
-                        title: "Associate Vice Chancellor, Compliance",
-                        children: [
-                            {
-                                title: "Director, Institutional Animal Care and Use Committee",
-                                weight: 2,
-                            },
-                            {
-                                title: "Director, Division of Research Safety",
-                                weight: 2,
-                            },
-                            {
-                                title: "Director, Office for the Protection of Research Subjects",
-                                weight: 2,
-                            },
-                            {
-                                title: "Director, Agricultural Animal Care and Use Program",
-                                weight: 2,
-                            },
-                        ],
-                    },
-                ],
-            };
-
-            let chart = document.getElementById("chart");
-            chart.org = org2;
-        </script>
-    </body>
-</html>
+        </body>
+        </html>

--- a/src/ilw-org-chart.css
+++ b/src/ilw-org-chart.css
@@ -1,3 +1,8 @@
+ilw-org-chart {
+    display: block;
+    max-width: 100%;
+}
+
 .ilw-org-chart {
     background-color: var(--ilw-color--heading);
     color: var(--ilw-color--background);

--- a/src/ilw-org-chart.ts
+++ b/src/ilw-org-chart.ts
@@ -33,8 +33,8 @@ export default class OrgChart extends LitElement {
     @property()
     org: Org | null = null;
 
-    @property({type: Number, reflect: true})
-    width = 1200;
+    @property({type: Number})
+    width: number | null = null;
 
     @property({type: Boolean})
     responsive = false;
@@ -47,6 +47,11 @@ export default class OrgChart extends LitElement {
 
     @query(".ilw-org-chart-canvas")
     canvas!: HTMLCanvasElement;
+
+    @state()
+    responsiveWidth = this.clientWidth;
+
+    private resizeObserver: ResizeObserver | null = null;
 
     /**
      * Set/get the ID of the currently selected org box.
@@ -90,41 +95,79 @@ export default class OrgChart extends LitElement {
     };
 
     _treeTask = new Task(this, {
-        task: async ([org]) => {
+        // This task should never use "this", but rather pass
+        // the necessary values as args
+        args: () =>
+            [
+                this.org,
+                this.responsive,
+                this.width,
+                this.responsiveWidth,
+            ] as const,
+        task: async ([org, responsive, width, responsiveWidth]) => {
             if (!org) {
                 return null;
             }
-            this.setResponsiveWidth();
-            OrgChart.config.availableSpace = this.width;
+            let useWidth = width || 1200;
+            if (responsive) {
+                useWidth = responsiveWidth;
+            }
+
+            if (useWidth < OrgChart.config.minColWidth) {
+                useWidth =
+                    OrgChart.config.minColWidth +
+                    2 * OrgChart.config.horizontalSpacing;
+            }
+
+            const config = {
+                ...OrgChart.config,
+                availableSpace: useWidth,
+            };
+
             const tree = treeLevelOrgs(org);
-            calculateLevelOrientations(tree, OrgChart.config);
-            const measured = measureOrgBoxes(
-                tree,
-                "ilw-org-chart",
-                OrgChart.config,
-            );
-            const lines = calculateLinesBetweenOrgs(
-                tree,
-                measured,
-                OrgChart.config,
-            );
+            calculateLevelOrientations(tree, config);
+            const measured = measureOrgBoxes(tree, "ilw-org-chart", config);
+            const lines = calculateLinesBetweenOrgs(tree, measured, config);
             return {
                 tree,
                 measured,
                 lines,
+                width: useWidth,
             };
         },
-        args: () => [this.org] as const,
     });
 
     connectedCallback() {
-        console.log('connectedCallback called');
         super.connectedCallback();
-        window.addEventListener("resize", this.setResponsiveWidthAndRebuild.bind(this));
+        this.syncResponsiveObserver();
     }
 
+    private updateResponsiveWidth = () => {
+        if (this.responsive) {
+            this.responsiveWidth = this.clientWidth;
+        }
+    };
+
+    private syncResponsiveObserver = () => {
+        if (this.responsive) {
+            if (!this.resizeObserver) {
+                this.responsiveWidth = this.clientWidth;
+                this.resizeObserver = new ResizeObserver(
+                    this.updateResponsiveWidth,
+                );
+                this.resizeObserver.observe(this);
+            }
+        } else if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
+            this.responsiveWidth = 1200;
+            this.refreshTask();
+        }
+    };
+
     disconnectedCallback() {
-        window.removeEventListener("resize", this.setResponsiveWidthAndRebuild.bind(this));
+        this.resizeObserver?.disconnect();
+        this.resizeObserver = null;
         super.disconnectedCallback();
     }
 
@@ -147,20 +190,6 @@ export default class OrgChart extends LitElement {
         }
     }
 
-    private setResponsiveWidth() {
-        if (this.responsive) {
-            this.width = Math.floor(this.offsetWidth);
-        }
-    }
-
-    private setResponsiveWidthAndRebuild() {
-        if (this.responsive) {
-            this.setResponsiveWidth();
-            this.refreshTask();
-        }
-    }
-
-
     private setFocusToNextSibling(id: number) {
         const org = this._treeTask.value?.tree.findNextSibling(id);
         if (org) {
@@ -173,7 +202,6 @@ export default class OrgChart extends LitElement {
         if (org) {
             this.selectedId = org.id;
         }
-
     }
     private setFocusToChild(id: number) {
         const org = this._treeTask.value?.tree.findFirstChild(id);
@@ -295,29 +323,31 @@ export default class OrgChart extends LitElement {
         if (isSelected) {
             classes["ilw-org-chart-selected"] = true;
         }
-        return html`
-            <li class="org-container" role="none">
-                <a
-                    id="org-${org.id}"
-                    role="treeitem"
-                    aria-expanded=${isParent ? "true" : nothing}
-                    aria-selected=${isSelected ? "true" : "false"}
-                    tabindex=${isSelected ? "0" : "-1"}
-                    @click=${(e: MouseEvent) => this.clickHandler(e, org.id)}
-                    @keydown=${(e: KeyboardEvent) => this.keydownHandler(e, org.id)}
-                    class=${classMap(classes)} style=${styleMap(styles)}
-                    aria-owns=${isParent ? `org-children-${org.id}` : nothing}
-                    href="#org-${org.id}"
-                >
-                    <span class="org-title">${org.title}</span>
-                    <span class="org-subtitle">${org.subtitle}</span>
-                </a>
-                ${
-                    org.children && org.children.length > 0
-                        ? this.renderChildren(`org-children-${org.id}`, org.children, placements)
-                        : ""
-                }
-            </li>`;
+        return html` <li class="org-container" role="none">
+            <a
+                id="org-${org.id}"
+                role="treeitem"
+                aria-expanded=${isParent ? "true" : nothing}
+                aria-selected=${isSelected ? "true" : "false"}
+                tabindex=${isSelected ? "0" : "-1"}
+                @click=${(e: MouseEvent) => this.clickHandler(e, org.id)}
+                @keydown=${(e: KeyboardEvent) => this.keydownHandler(e, org.id)}
+                class=${classMap(classes)}
+                style=${styleMap(styles)}
+                aria-owns=${isParent ? `org-children-${org.id}` : nothing}
+                href="#org-${org.id}"
+            >
+                <span class="org-title">${org.title}</span>
+                <span class="org-subtitle">${org.subtitle}</span>
+            </a>
+            ${org.children && org.children.length > 0
+                ? this.renderChildren(
+                      `org-children-${org.id}`,
+                      org.children,
+                      placements,
+                  )
+                : ""}
+        </li>`;
     }
 
     render() {
@@ -325,8 +355,8 @@ export default class OrgChart extends LitElement {
             if (this.selectedId === -1) {
                 this.selectedId = this._treeTask.value.tree.root.id;
             }
+            let width = this._treeTask.value.width;
             let height = 0;
-            this.setResponsiveWidth();
 
             for (const placement of this._treeTask.value.measured.values()) {
                 height = Math.max(height, placement.top + placement.height);
@@ -334,14 +364,21 @@ export default class OrgChart extends LitElement {
             let primaryOrientation = this._treeTask.value.tree.primaryOrientation;
             return html`<div
                 class="ilw-org-chart-container"
-                style="width: ${this.width}px; height: ${height + 20}px;"
+                style="width: ${width}px; height: ${height + 20}px;"
             >
-                <canvas
-                    class="ilw-org-chart-canvas"
-                    width=${this.width}
-                    height=${height + 20}
-                ></canvas>
-                <ul class="ilw-org-chart-top ${this.theme}" aria-label=${this.label} role="tree" aria-orientation="${primaryOrientation}">
+                ${!this.hidelines
+                    ? html`<canvas
+                          class="ilw-org-chart-canvas"
+                          width=${width}
+                          height=${height + 20}
+                      ></canvas>`
+                    : nothing}
+                <ul
+                    class="ilw-org-chart-top ${this.theme}"
+                    aria-label=${this.label}
+                    role="tree"
+                    aria-orientation="${primaryOrientation}"
+                >
                     ${this._treeTask.value
                         ? this.renderOrg(
                               this._treeTask.value.tree.root,
@@ -358,17 +395,17 @@ export default class OrgChart extends LitElement {
     protected updated(_changedProperties: PropertyValues): void {
         super.updated(_changedProperties);
 
+        if (_changedProperties.has("responsive")) {
+            this.syncResponsiveObserver();
+        }
+
         const ctx = this.canvas?.getContext("2d");
         if (ctx) {
             ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
             ctx.strokeStyle = this.theme == '' || (this.theme == 'white' || this.theme == 'gray')? "#000000" : "#ffffff";
             ctx.lineWidth = 4;
-            let displayLines = !this.hidelines;
-            if (this.responsive) {
-                displayLines = true;
-            }
 
-            if (displayLines && this._treeTask.value?.lines) {
+            if (this._treeTask.value?.lines) {
                 for (const line of this._treeTask.value.lines) {
                     ctx.beginPath();
                     let start = line.points[0];

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -411,7 +411,6 @@ export function measureOrgBoxes(
     cssClass: string,
     config: OrgChartConfig,
 ) {
-    console.log("[measureOrgBoxes] Start measuring org boxes", levelsMap);
     const startTime = performance.now();
 
     // Create hidden container
@@ -524,7 +523,6 @@ export function measureOrgBoxes(
                 Math.max(unitWidth * 1.0, config.minColWidth),
                 config.maxColWidth,
             );
-            console.log("totalUnits, unitWidth, largeOrgWidth, smallOrgWidth", totalUnits, unitWidth, largeOrgWidth, smallOrgWidth);
 
             levelContainer.style.width = realAvailableSpace + "px";
             container.appendChild(levelContainer);
@@ -629,12 +627,6 @@ export function measureOrgBoxes(
     document.body.removeChild(container);
     const endTime = performance.now();
     const duration = endTime - startTime;
-    console.log(
-        `[measureOrgBoxes] Finished measuring. Duration: ${duration.toFixed(2)} ms`,
-        orgSizes,
-    );
-    console.log("[measureOrgBoxes] Measured org sizes:", orgSizes);
-    console.log("[measureOrgBoxes] Updated placements:", updated);
 
     return orgSizes;
 }
@@ -997,6 +989,115 @@ function calculateLinesForOrg(
         const orgIsLastInLevel =
             orgLevelObj?.orgs[orgLevelObj.orgs.length - 1] === org;
 
+        // The best corridor should only be used if there is a single parent
+        // in the horizontal level. If there are more, fall back to the edge.
+        const uniqueParentsInLevel = new Set<number>();
+        for (const levelOrg of orgLevelObj?.orgs ?? []) {
+            if (levelOrg.parent) {
+                uniqueParentsInLevel.add(levelOrg.parent.id);
+            }
+        }
+        const singleParentInLevel = uniqueParentsInLevel.size <= 1;
+
+        const centerX = (placement.left || 0) + placement.width / 2;
+        const parentLeft = placement.left || 0;
+        const parentRight = parentLeft + placement.width;
+
+        const findBestCorridorMidpoint = (
+            intervals: { start: number; end: number }[],
+            preferredX: number,
+        ) => {
+            let bestX: number | null = null;
+            let bestDistance = Infinity;
+            for (const interval of intervals) {
+                const midpoint = (interval.start + interval.end) / 2;
+                const distance = Math.abs(midpoint - preferredX);
+                if (distance < bestDistance) {
+                    bestDistance = distance;
+                    bestX = midpoint;
+                }
+            }
+            return bestX;
+        };
+
+        const intersectIntervals = (
+            a: { start: number; end: number }[],
+            b: { start: number; end: number }[],
+        ) => {
+            const intersections: { start: number; end: number }[] = [];
+            for (const ia of a) {
+                for (const ib of b) {
+                    const start = Math.max(ia.start, ib.start);
+                    const end = Math.min(ia.end, ib.end);
+                    if (end > start) {
+                        intersections.push({ start, end });
+                    }
+                }
+            }
+            return intersections;
+        };
+
+        const findSkipStartX = (targetLevel: number) => {
+            let safeCorridors: { start: number; end: number }[] = [
+                { start: 0, end: config.availableSpace },
+            ];
+            for (let levelNum = org.level + 1; levelNum < targetLevel; levelNum++) {
+                const level = levelsMap.get(levelNum);
+                if (!level || !level.emptySpaces || level.emptySpaces.length === 0) {
+                    continue;
+                }
+                safeCorridors = intersectIntervals(safeCorridors, level.emptySpaces);
+                if (safeCorridors.length === 0) {
+                    break;
+                }
+            }
+
+            if (singleParentInLevel && safeCorridors.length > 0) {
+                const corridorsInsideParent = intersectIntervals(safeCorridors, [
+                    { start: parentLeft, end: parentRight },
+                ]);
+                const bestInsideParent = findBestCorridorMidpoint(
+                    corridorsInsideParent,
+                    centerX,
+                );
+                const bestOverall = findBestCorridorMidpoint(
+                    safeCorridors,
+                    centerX,
+                );
+                return bestInsideParent ?? bestOverall ?? centerX;
+            }
+
+            if (orgIsLastInLevel) {
+                return (
+                    (placement.left || 0) +
+                    placement.width -
+                    config.skipLineExtraSpacing / 2
+                );
+            }
+            if (orgIsFirstInLevel) {
+                return (placement.left || 0) + config.skipLineExtraSpacing / 2;
+            }
+            return centerX;
+        };
+
+        let sharedDownStartX: number | null = null;
+        if (org.lineSkipsLevels && org.lineSkipsLevels > 0) {
+            const childrenWithPlacement = org.children
+                .map((child) => ({ child, childPlacement: placements.get(child.id) }))
+                .filter(
+                    (entry): entry is { child: ConnectedOrg; childPlacement: OrgPlacement } =>
+                        !!entry.childPlacement && entry.child.level > org.level,
+                );
+
+            if (childrenWithPlacement.length > 0) {
+                childrenWithPlacement.sort(
+                    (a, b) =>
+                        (b.child.level - org.level) - (a.child.level - org.level),
+                );
+                sharedDownStartX = findSkipStartX(childrenWithPlacement[0].child.level);
+            }
+        }
+
         for (const child of org.children) {
             const childPlacement = placements.get(child.id);
             const isChildVerticalLevel =
@@ -1017,49 +1118,7 @@ function calculateLinesForOrg(
                         y: childPlacement.top + childPlacement.height / 2,
                     });
                 } else if (org.lineSkipsLevels && org.lineSkipsLevels > 0) {
-                    // Start the line half of skipLineExtraSpacing from the edge of parent
-                    let startX: number;
-
-                    const level = levelsMap.get(org.level + 1)!;
-                    // If the line skips levels, but it's not skipping at the edges,
-                    // we want to start the line from the closest gap to the center of the org
-                    if (!level?.leftSkipLine && !level?.rightSkipLine) {
-                        // Find the closest gap to the center of the org
-                        const emptySpaces = level.emptySpaces || [];
-                        const centerX =
-                            (placement.left || 0) + placement.width / 2;
-                        let closestGap: { start: number; end: number } | null =
-                            null;
-                        let closestDistance = Infinity;
-                        for (const gap of emptySpaces) {
-                            const gapCenter = (gap.start + gap.end) / 2;
-                            const distance = Math.abs(gapCenter - centerX);
-                            if (distance < closestDistance) {
-                                closestDistance = distance;
-                                closestGap = gap;
-                            }
-                        }
-                        if (closestGap) {
-                            startX = (closestGap.start + closestGap.end) / 2;
-                        } else {
-                            startX = centerX; // fallback
-                        }
-                    } else if (orgIsLastInLevel) {
-                        // Start from the right edge of the org
-                        startX =
-                            (placement.left || 0) +
-                            placement.width -
-                            config.skipLineExtraSpacing / 2;
-                    } else if (orgIsFirstInLevel) {
-                        // Start from the left edge of the org
-                        startX =
-                            (placement.left || 0) +
-                            config.skipLineExtraSpacing / 2;
-                    } else {
-                        // Fallback to center
-                        startX =
-                            (placement.left || 0) + placement.width / 2;
-                    }
+                    const startX = sharedDownStartX ?? findSkipStartX(child.level);
 
                     line.points.push({
                         x: startX,


### PR DESCRIPTION
Aside from the line placement improvements, these changes tighten up the responsive logic to avoid partial updates and race conditions. Lit's task library automatically prevents two task results from overlapping, so we just need to make sure the task is purely functional, aside from the static config defaults.

This should hopefully address #8, at least I could no longer reproduce those issues on my end.